### PR TITLE
Fix cache error handling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,5 +28,8 @@ jobs:
     - name: Test
       run: go test -v ./...
 
+    - name: Test Race
+      run: go test -race ./...
+
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9

--- a/switchbot/cache.go
+++ b/switchbot/cache.go
@@ -37,6 +37,9 @@ func (c *cache) GetMetrics(ctx context.Context) (float32, float32, error) {
 	}
 
 	temp, hum, err := c.c.GetMetrics(ctx)
+	if err != nil {
+		return 0.0, 0.0, err
+	}
 
 	c.set(temp, hum)
 

--- a/switchbot/cache.go
+++ b/switchbot/cache.go
@@ -31,7 +31,7 @@ func NewCacheClient(c Client) Client {
 }
 
 func (c *cache) GetMetrics(ctx context.Context) (float32, float32, error) {
-	if c.expire.After(time.Now()) {
+	if c.isFresh() {
 		t, h := c.get()
 		return t, h, nil
 	}
@@ -41,11 +41,16 @@ func (c *cache) GetMetrics(ctx context.Context) (float32, float32, error) {
 		return 0.0, 0.0, err
 	}
 
-	c.set(temp, hum)
-
-	c.expire = time.Now().Add(c.ttl)
+	c.setMetrics(temp, hum, time.Now().Add(c.ttl))
 
 	return temp, hum, err
+}
+
+func (c *cache) isFresh() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.expire.After(time.Now())
 }
 
 func (c *cache) get() (float32, float32) {
@@ -55,10 +60,11 @@ func (c *cache) get() (float32, float32) {
 	return c.temp, c.hum
 }
 
-func (c *cache) set(temp, hum float32) {
+func (c *cache) setMetrics(temp, hum float32, expire time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.temp = temp
 	c.hum = hum
+	c.expire = expire
 }

--- a/switchbot/cache_test.go
+++ b/switchbot/cache_test.go
@@ -1,0 +1,78 @@
+package switchbot
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type clientFunc func(context.Context) (float32, float32, error)
+
+func (f clientFunc) GetMetrics(ctx context.Context) (float32, float32, error) {
+	return f(ctx)
+}
+
+func TestCacheStoresSuccessfulMetrics(t *testing.T) {
+	calls := 0
+	client := clientFunc(func(context.Context) (float32, float32, error) {
+		calls++
+		if calls == 1 {
+			return 23.5, 48, nil
+		}
+
+		return 99, 99, nil
+	})
+	cache := NewCacheClient(client)
+
+	temp, hum, err := cache.GetMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("expected fresh metrics, got %v", err)
+	}
+	if temp != 23.5 || hum != 48 {
+		t.Fatalf("expected fresh metrics, got temp=%v hum=%v", temp, hum)
+	}
+
+	temp, hum, err = cache.GetMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("expected cached metrics, got %v", err)
+	}
+	if temp != 23.5 || hum != 48 {
+		t.Fatalf("expected cached metrics, got temp=%v hum=%v", temp, hum)
+	}
+	if calls != 1 {
+		t.Fatalf("expected successful metrics to be cached, got %d calls", calls)
+	}
+}
+
+func TestCacheDoesNotStoreFailedMetrics(t *testing.T) {
+	temporaryErr := errors.New("temporary error")
+	calls := 0
+	client := clientFunc(func(context.Context) (float32, float32, error) {
+		calls++
+		if calls == 1 {
+			return 0, 0, temporaryErr
+		}
+
+		return 24.5, 51, nil
+	})
+	cache := NewCacheClient(client)
+
+	temp, hum, err := cache.GetMetrics(context.Background())
+	if !errors.Is(err, temporaryErr) {
+		t.Fatalf("expected temporary error, got %v", err)
+	}
+	if temp != 0 || hum != 0 {
+		t.Fatalf("failed response should return zero values, got temp=%v hum=%v", temp, hum)
+	}
+
+	temp, hum, err = cache.GetMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got %v", err)
+	}
+	if temp != 24.5 || hum != 51 {
+		t.Fatalf("expected fresh metrics after failure, got temp=%v hum=%v", temp, hum)
+	}
+	if calls != 2 {
+		t.Fatalf("expected failed metrics not to be cached, got %d calls", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid caching zero metrics when SwitchBot metric fetch fails
- add cache tests for failed and successful metric fetches
## Tests
- ?   	roomctl	[no test files]
?   	roomctl/collector	[no test files]
?   	roomctl/config	[no test files]
?   	roomctl/echonetlite	[no test files]
?   	roomctl/prom	[no test files]
=== RUN   TestCacheStoresSuccessfulMetrics
--- PASS: TestCacheStoresSuccessfulMetrics (0.00s)
=== RUN   TestCacheDoesNotStoreFailedMetrics
--- PASS: TestCacheDoesNotStoreFailedMetrics (0.00s)
=== RUN   TestHmacSHA256
--- PASS: TestHmacSHA256 (0.00s)
PASS
ok  	roomctl/switchbot	(cached)
- ok  	roomctl/switchbot	(cached)